### PR TITLE
Enable bf16 support by using +/-inf constants

### DIFF
--- a/src/pytorch_metric_learning/utils/common_functions.py
+++ b/src/pytorch_metric_learning/utils/common_functions.py
@@ -36,11 +36,16 @@ def set_logger_name(name):
 
 
 def pos_inf(dtype):
-    return torch.finfo(dtype).max
+    # Use actual infinity to avoid overflow when converting to lower precision
+    # dtypes such as bfloat16. torch.finfo(dtype).max may exceed the representable
+    # range for some dtypes when converted from Python floats.
+    return float("inf")
 
 
 def neg_inf(dtype):
-    return torch.finfo(dtype).min
+    # Similar to ``pos_inf``, use negative infinity to ensure the value can be
+    # safely converted to any dtype without overflow.
+    return float("-inf")
 
 
 def small_val(dtype):


### PR DESCRIPTION
## Summary
- avoid overflow for bfloat16 by using infinite constants in `pos_inf` and `neg_inf`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68448e1ccb188322b4a45435de5ad46d